### PR TITLE
Add wall ball debugging instrumentation

### DIFF
--- a/workout/utilities/movement_counters.py
+++ b/workout/utilities/movement_counters.py
@@ -542,7 +542,27 @@ class WallBallCounter(BaseCounter):
     def get_stats(self) -> dict:
         stats = super().get_stats()
         stats['rep_log'] = self._rep_log
+        stats['phase'] = self._phase
         return stats
+
+    def get_debug_state(self) -> dict:
+        """Return state-machine internals for wall-ball diagnostics."""
+        return {
+            'phase': self._phase,
+            'squat_achieved': self._squat_achieved,
+            'ball_at_target_achieved': self._ball_at_target_achieved,
+            'target_y_px': self.target_y_px,
+            'ball_y': self._ball_y(),
+            'ball_loss_frames': self._ball_loss_frames,
+            'throw_frame_count': self._throw_frame_count,
+            'phase_frames': self._phase_frames,
+            'throw_min_y': self._throw_min_y,
+            'shoulder_y_px': self._shoulder_y_px,
+            'wrist_y_px': self._wrist_y_px,
+            'count': self.count,
+            'no_rep': self.no_rep,
+            'outcome': self.outcome,
+        }
 
     def update_ball_position(self, ball_detection: dict | None) -> None:
         """

--- a/workout/utilities/object_detector.py
+++ b/workout/utilities/object_detector.py
@@ -91,12 +91,15 @@ class GymObjectDetector:
                 'ball': {'centroid': (cx, cy), 'bbox': (x1,y1,x2,y2), 'confidence': float}
                         or None if no ball detected.
                 'frame_idx': int
+                'source': 'yolo' | 'tracker' | 'none'
         """
         ball = None
+        source = 'none'
 
         if frame_idx % self.detect_every_n_frames == 0:
             ball = self._run_yolo(frame, athlete_torso_bbox)
             if ball:
+                source = 'yolo'
                 x1, y1, x2, y2 = ball['bbox']
                 w, h = x2 - x1, y2 - y1
                 self._last_bbox = (x1, y1, w, h)
@@ -105,8 +108,10 @@ class GymObjectDetector:
                 self._tracker_active = False
         else:
             ball = self._update_tracker(frame)
+            if ball:
+                source = 'tracker'
 
-        return {'ball': ball, 'frame_idx': frame_idx}
+        return {'ball': ball, 'frame_idx': frame_idx, 'source': source}
 
     def reset_tracker(self) -> None:
         """Reset the CSRT tracker (call between reps or at start of new set)."""

--- a/workout/utilities/wall_ball_analyser.py
+++ b/workout/utilities/wall_ball_analyser.py
@@ -7,6 +7,9 @@ is a drop-in replacement for the Celery task.
 """
 import logging
 import os
+import json
+from datetime import datetime
+from pathlib import Path
 
 import cv2
 
@@ -49,11 +52,14 @@ class WallBallAnalyser:
         target_y_px: int | None = None,
         detect_every_n_frames: int = 3,
         calibration_frames: int = 30,
+        debug_dir: str | None = None,
     ):
         self.video = cv2.VideoCapture(video_path)
+        self.video_path = video_path
         self.expected_reps = expected_reps
         self.criteria = criteria
         self.calibration_frames = calibration_frames
+        self.debug_dir = _prepare_debug_dir(debug_dir)
 
         # Perception modules
         self.pose_detector = pm.PoseDetector()
@@ -72,6 +78,10 @@ class WallBallAnalyser:
             self.counter.set_target_y(target_y_px)
 
         self._frame_idx: int = 0
+        self._diagnostics = _new_diagnostics(video_path, expected_reps)
+        self._last_count = 0
+        self._last_no_rep = 0
+        self._last_phase = self.counter.get_debug_state()['phase']
 
         # Pass video FPS to the counter so it can convert frame numbers to seconds.
         fps = self.video.get(cv2.CAP_PROP_FPS)
@@ -190,6 +200,9 @@ class WallBallAnalyser:
             'rounds_completed': 1 if (is_valid and total_reps > 0) else 0,
             'target_y_px': self.target_detector.target_y_px,
             'rep_log': stats.get('rep_log', []),
+            'good_reps': total_reps,
+            'attempted_reps': total_reps + total_no_reps,
+            'diagnostics': self._finalise_diagnostics(),
         }
 
     # ------------------------------------------------------------------
@@ -267,6 +280,7 @@ class WallBallAnalyser:
 
     def _process_frame(self, img) -> dict:
         """Process one frame. Returns a small diagnostic dict for the analyse() summary."""
+        raw_img = img.copy() if self.debug_dir else None
         # 1. Pose detection
         img = self.pose_detector.getPose(img, draw=False)
         lmList = self.pose_detector.getPosition(img, draw=False)
@@ -288,10 +302,12 @@ class WallBallAnalyser:
         # 3. Ball detection — build athlete torso bbox from landmarks to filter FPs.
         athlete_torso_bbox = _torso_bbox(lmList) if lmList else None
         detection = self.object_detector.detect(img, self._frame_idx, athlete_torso_bbox)
-        self.counter.update_ball_position(detection.get('ball'))
+        ball = detection.get('ball')
+        self.counter.update_ball_position(ball)
 
         # 4. Squat angle + counter
         if not lmList:
+            self._record_frame_diagnostics(None, None, detection, None)
             return {'pose_missing': True}
 
         try:
@@ -299,6 +315,7 @@ class WallBallAnalyser:
             angle = self.pose_detector.getAngle(None, hip, knee, ankle)
         except Exception as exc:
             logger.debug("Angle computation failed on frame %d: %s", self._frame_idx, exc)
+            self._record_frame_diagnostics(lmList, None, detection, athlete_torso_bbox)
             return {'angle_error': True}
 
         wall_ball_criteria = self.criteria.get('wall_ball', {})
@@ -311,11 +328,116 @@ class WallBallAnalyser:
         )
 
         self.counter.process(angle, lmList, self.pose_detector, direction)
+        self._record_frame_diagnostics(lmList, angle, detection, athlete_torso_bbox)
+        self._maybe_save_event_snapshot(raw_img, angle, ball, athlete_torso_bbox)
 
         # 5. Dynamic target recalibration from observed ball peaks.
         self._maybe_recalibrate_target()
 
         return {'angle': angle}
+
+    def _record_frame_diagnostics(
+        self,
+        lmList: list | None,
+        angle: float | None,
+        detection: dict,
+        athlete_torso_bbox: tuple | None,
+    ) -> None:
+        """Collect cheap per-frame metrics for post-run debugging."""
+        diag = self._diagnostics
+        diag['frames_processed'] += 1
+
+        ball = detection.get('ball')
+        source = detection.get('source', 'none')
+        diag['ball_detection_sources'][source] = diag['ball_detection_sources'].get(source, 0) + 1
+        if ball:
+            diag['frames_with_ball'] += 1
+        else:
+            diag['frames_without_ball'] += 1
+
+        if lmList:
+            diag['frames_with_pose'] += 1
+        else:
+            diag['frames_without_pose'] += 1
+
+        if angle is not None:
+            diag['angle_min'] = angle if diag['angle_min'] is None else min(diag['angle_min'], angle)
+            diag['angle_max'] = angle if diag['angle_max'] is None else max(diag['angle_max'], angle)
+
+        state = self.counter.get_debug_state()
+        phase = state['phase']
+        diag['phase_frame_counts'][phase] = diag['phase_frame_counts'].get(phase, 0) + 1
+        if phase != self._last_phase:
+            diag['phase_transitions'].append({
+                'frame': self._frame_idx,
+                'from': self._last_phase,
+                'to': phase,
+                'angle': round(angle, 2) if angle is not None else None,
+                'ball_y': state['ball_y'],
+                'target_y_px': state['target_y_px'],
+            })
+            self._last_phase = phase
+
+        sample_every = int(self.criteria.get('wall_ball', {}).get('debug_sample_every_n_frames', 30))
+        if sample_every > 0 and self._frame_idx % sample_every == 0:
+            diag['frame_samples'].append({
+                'frame': self._frame_idx,
+                'angle': round(angle, 2) if angle is not None else None,
+                'ball': ball,
+                'ball_source': source,
+                'torso_bbox': athlete_torso_bbox,
+                **state,
+            })
+
+    def _maybe_save_event_snapshot(
+        self,
+        raw_img,
+        angle: float | None,
+        ball: dict | None,
+        athlete_torso_bbox: tuple | None,
+    ) -> None:
+        """Save timestamped overlay images when reps/no-reps are recorded."""
+        if raw_img is None or not self.debug_dir:
+            self._last_count = self.counter.count
+            self._last_no_rep = self.counter.no_rep
+            return
+
+        event = None
+        if self.counter.count > self._last_count:
+            event = f"good_rep_{self.counter.count:03d}"
+        elif self.counter.no_rep > self._last_no_rep:
+            event = f"no_rep_{self.counter.no_rep:03d}"
+
+        self._last_count = self.counter.count
+        self._last_no_rep = self.counter.no_rep
+
+        if event is None:
+            return
+
+        overlay = raw_img.copy()
+        _draw_debug_overlay(
+            overlay,
+            frame_idx=self._frame_idx,
+            angle=angle,
+            ball=ball,
+            target_y_px=self.target_detector.target_y_px,
+            tolerance=self.counter.ball_height_tolerance_px,
+            torso_bbox=athlete_torso_bbox,
+            state=self.counter.get_debug_state(),
+        )
+        path = self.debug_dir / f"{self._frame_idx:06d}_{event}.jpg"
+        cv2.imwrite(str(path), overlay)
+        self._diagnostics['artifacts'].append(str(path))
+
+    def _finalise_diagnostics(self) -> dict:
+        self._diagnostics['target_y_px'] = self.target_detector.target_y_px
+        self._diagnostics['rep_log'] = self.counter.get_stats().get('rep_log', [])
+        if self.debug_dir:
+            path = self.debug_dir / 'wall_ball_diagnostics.json'
+            path.write_text(json.dumps(self._diagnostics, indent=2), encoding='utf-8')
+            self._diagnostics['artifacts'].append(str(path))
+            self._diagnostics['debug_dir'] = str(self.debug_dir)
+        return self._diagnostics
 
     def _maybe_recalibrate_target(self) -> None:
         """
@@ -352,6 +474,7 @@ def analyse_wall_ball_video(
     video_url: str,
     expected_reps: int | None = None,
     target_y_px: int | None = None,
+    debug_dir: str | None = None,
 ) -> dict:
     """
     Download/locate a video and run wall ball analysis.
@@ -360,6 +483,7 @@ def analyse_wall_ball_video(
         video_url:      YouTube URL or local file path.
         expected_reps:  Target rep count for validity check.
         target_y_px:    Optional manual target Y coordinate (skips auto-detect).
+        debug_dir:      Optional directory for diagnostics JSON and event snapshots.
 
     Returns:
         Analysis result dict (same shape as WorkoutAnalyser.analyse()).
@@ -380,6 +504,7 @@ def analyse_wall_ball_video(
             expected_reps=expected_reps,
             criteria=criteria,
             target_y_px=target_y_px,
+            debug_dir=debug_dir,
         )
         return analyser.analyse()
     finally:
@@ -390,6 +515,81 @@ def analyse_wall_ball_video(
 # ------------------------------------------------------------------
 # Utility
 # ------------------------------------------------------------------
+
+def _prepare_debug_dir(debug_dir: str | None) -> Path | None:
+    """Create a diagnostics directory when explicitly requested."""
+    configured = debug_dir or os.getenv('JUDGEFIT_WALLBALL_DEBUG_DIR')
+    if not configured:
+        return None
+
+    path = Path(configured) / datetime.utcnow().strftime('%Y%m%d_%H%M%S_%f')
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _new_diagnostics(video_path: str, expected_reps: int | None) -> dict:
+    return {
+        'video_path': video_path,
+        'expected_reps': expected_reps,
+        'frames_processed': 0,
+        'frames_with_pose': 0,
+        'frames_without_pose': 0,
+        'frames_with_ball': 0,
+        'frames_without_ball': 0,
+        'ball_detection_sources': {},
+        'angle_min': None,
+        'angle_max': None,
+        'target_y_px': None,
+        'phase_frame_counts': {},
+        'phase_transitions': [],
+        'frame_samples': [],
+        'rep_log': [],
+        'artifacts': [],
+    }
+
+
+def _draw_debug_overlay(
+    img,
+    frame_idx: int,
+    angle: float | None,
+    ball: dict | None,
+    target_y_px: int | None,
+    tolerance: int,
+    torso_bbox: tuple | None,
+    state: dict,
+) -> None:
+    """Draw a compact event snapshot overlay for audit/debugging."""
+    h, w = img.shape[:2]
+
+    if target_y_px is not None:
+        zone_top = max(target_y_px - tolerance, 0)
+        zone_bot = min(target_y_px + tolerance, h - 1)
+        cv2.rectangle(img, (0, zone_top), (w, zone_bot), (0, 80, 0), -1)
+        cv2.line(img, (0, target_y_px), (w, target_y_px), (0, 255, 0), 2)
+
+    if torso_bbox:
+        x1, y1, x2, y2 = [int(v) for v in torso_bbox]
+        cv2.rectangle(img, (x1, y1), (x2, y2), (255, 0, 255), 2)
+
+    if ball:
+        x1, y1, x2, y2 = ball['bbox']
+        cx, cy = ball['centroid']
+        cv2.rectangle(img, (x1, y1), (x2, y2), (0, 165, 255), 2)
+        cv2.circle(img, (cx, cy), 5, (0, 165, 255), -1)
+
+    lines = [
+        f"frame={frame_idx}",
+        f"phase={state['phase']}",
+        f"good={state['count']} no_rep={state['no_rep']}",
+        f"angle={angle:.1f}" if angle is not None else "angle=None",
+        f"target_y={target_y_px}",
+        f"ball_y={state['ball_y']}",
+        f"outcome={state['outcome']}",
+    ]
+    for i, text in enumerate(lines):
+        y = 28 + (i * 24)
+        cv2.putText(img, text, (16, y), cv2.FONT_HERSHEY_SIMPLEX, 0.65, (0, 0, 0), 4)
+        cv2.putText(img, text, (16, y), cv2.FONT_HERSHEY_SIMPLEX, 0.65, (255, 255, 255), 2)
 
 def _torso_bbox(lmList: list) -> tuple | None:
     """


### PR DESCRIPTION
## Summary
- add wall-ball diagnostics for pose, ball detection, phase transitions, frame samples, and rep logs
- add optional debug output via `JUDGEFIT_WALLBALL_DEBUG_DIR` with JSON diagnostics and event overlay snapshots
- expose object detection source and wall-ball counter debug state
- include `good_reps` and `attempted_reps` in wall-ball analysis output

## Verification
- `python3 -m py_compile workout/utilities/wall_ball_analyser.py workout/utilities/object_detector.py workout/utilities/movement_counters.py`